### PR TITLE
Prepare .NET SDK 2.3.1 follow-up release

### DIFF
--- a/tests/ClientRequestTest.cs
+++ b/tests/ClientRequestTest.cs
@@ -1,0 +1,92 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Net;
+using System.Net.Sockets;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace tests
+{
+    [TestClass]
+    public class ClientRequestTest
+    {
+        [TestMethod]
+        public void GetAcceptsSuccessfulStatusCodes()
+        {
+            WithServer(async context =>
+            {
+                context.Response.StatusCode = 204;
+                context.Response.Close();
+                await Task.CompletedTask;
+            }, baseUrl =>
+            {
+                var client = new Trolley.Client(new Trolley.Configuration("access", "secret", baseUrl));
+
+                string response = client.Get("/success");
+
+                Assert.AreEqual("", response);
+            });
+        }
+
+        [TestMethod]
+        public void GatewayRequestDispatchesPatch()
+        {
+            string method = null;
+            string body = null;
+
+            WithServer(async context =>
+            {
+                method = context.Request.HttpMethod;
+                using (var reader = new System.IO.StreamReader(context.Request.InputStream, context.Request.ContentEncoding))
+                {
+                    body = await reader.ReadToEndAsync();
+                }
+
+                byte[] response = Encoding.UTF8.GetBytes("{\"ok\":true}");
+                context.Response.StatusCode = 202;
+                context.Response.ContentType = "application/json";
+                context.Response.OutputStream.Write(response, 0, response.Length);
+                context.Response.Close();
+            }, baseUrl =>
+            {
+                var gateway = new Trolley.Gateway("access", "secret", baseUrl);
+
+                string response = gateway.Request("PATCH", "/patch", "{\"enabled\":true}");
+
+                Assert.AreEqual("PATCH", method);
+                Assert.AreEqual("{\"enabled\":true}", body);
+                Assert.AreEqual("{\"ok\":true}", response);
+            });
+        }
+
+        private static void WithServer(Func<HttpListenerContext, Task> handler, Action<string> test)
+        {
+            int port = GetAvailablePort();
+            string baseUrl = $"http://localhost:{port}";
+
+            using (var listener = new HttpListener())
+            {
+                listener.Prefixes.Add(baseUrl + "/");
+                listener.Start();
+
+                Task server = Task.Run(async () =>
+                {
+                    HttpListenerContext context = await listener.GetContextAsync();
+                    await handler(context);
+                });
+
+                test(baseUrl);
+                server.GetAwaiter().GetResult();
+            }
+        }
+
+        private static int GetAvailablePort()
+        {
+            var listener = new TcpListener(IPAddress.Loopback, 0);
+            listener.Start();
+            int port = ((IPEndPoint)listener.LocalEndpoint).Port;
+            listener.Stop();
+            return port;
+        }
+    }
+}

--- a/trolley/Client.cs
+++ b/trolley/Client.cs
@@ -36,9 +36,9 @@ namespace Trolley
                 HttpResponseMessage response = httpClient.GetAsync(endPoint).Result;
 
                 result = response.Content.ReadAsStringAsync().Result;
-                if ((int)response.StatusCode != 200)
+                if (!response.IsSuccessStatusCode)
                 {
-                    ThrowStatusCodeException((int)response.StatusCode, response.Content.ReadAsStringAsync().Result);
+                    ThrowStatusCodeException((int)response.StatusCode, result);
                 }
             }
             catch (HttpRequestException)
@@ -88,9 +88,9 @@ namespace Trolley
                 httpClient = CreateRequest(endPoint, "POST", null, body);
                 HttpResponseMessage response = httpClient.PostAsync(endPoint, jsonBody).Result;
                 result = response.Content.ReadAsStringAsync().Result;
-                if ((int)response.StatusCode != 200)
+                if (!response.IsSuccessStatusCode)
                 {
-                    ThrowStatusCodeException((int)response.StatusCode, response.Content.ReadAsStringAsync().Result);
+                    ThrowStatusCodeException((int)response.StatusCode, result);
                 }
 
             }
@@ -120,9 +120,9 @@ namespace Trolley
 
                 HttpResponseMessage response = responseTask.Result;
                 result = response.Content.ReadAsStringAsync().Result;
-                if ((int)response.StatusCode != 200)
+                if (!response.IsSuccessStatusCode)
                 {
-                    ThrowStatusCodeException((int)response.StatusCode, response.Content.ReadAsStringAsync().Result);
+                    ThrowStatusCodeException((int)response.StatusCode, result);
                 }
             }
             catch (HttpRequestException)
@@ -152,9 +152,9 @@ namespace Trolley
 
                 HttpResponseMessage response = responseTask.Result;
                 result = response.Content.ReadAsStringAsync().Result;
-                if ((int)response.StatusCode != 200)
+                if (!response.IsSuccessStatusCode)
                 {
-                    ThrowStatusCodeException((int)response.StatusCode, response.Content.ReadAsStringAsync().Result);
+                    ThrowStatusCodeException((int)response.StatusCode, result);
                 }
             }
             catch (HttpRequestException)
@@ -195,9 +195,9 @@ namespace Trolley
                 
                 
                 result = response.Content.ReadAsStringAsync().Result;
-                if ((int)response.StatusCode != 200)
+                if (!response.IsSuccessStatusCode)
                 {
-                    ThrowStatusCodeException((int)response.StatusCode, response.Content.ReadAsStringAsync().Result);
+                    ThrowStatusCodeException((int)response.StatusCode, result);
                 }
             }
             catch (HttpRequestException)
@@ -206,6 +206,23 @@ namespace Trolley
             }
 
             return result;
+        }
+
+        public string Request(string method, string endPoint, string body = null)
+        {
+            switch (method.ToUpperInvariant())
+            {
+                case "GET":
+                    return Get(endPoint);
+                case "POST":
+                    return Post(endPoint, body);
+                case "PATCH":
+                    return Patch(endPoint, body);
+                case "DELETE":
+                    return Delete(endPoint, body);
+                default:
+                    throw new InvalidStatusCodeException("Unsupported HTTP method: " + method);
+            }
         }
 
 

--- a/trolley/Gateway.cs
+++ b/trolley/Gateway.cs
@@ -41,5 +41,10 @@
         {
         }
 
+        public string Request(string method, string endPoint, string body = null)
+        {
+            return this.client.Request(method, endPoint, body);
+        }
+
     }
 }

--- a/trolley/Types/Supporting/SemVer.cs
+++ b/trolley/Types/Supporting/SemVer.cs
@@ -4,8 +4,8 @@ namespace Trolley.Types.Supporting
 	public class SemVer
 	{
 		public static int MAJOR = 2;
-        public static int PATCH = 0;
-        public static int MINOR = 0;
+        public static int PATCH = 3;
+        public static int MINOR = 1;
 
 	}
 }

--- a/trolley/trolley.csproj
+++ b/trolley/trolley.csproj
@@ -15,7 +15,7 @@
     <UpdateRequired>false</UpdateRequired>
     <MapFileExtensions>true</MapFileExtensions>
     <ApplicationRevision>0</ApplicationRevision>
-    <ApplicationVersion>2.3.0.0</ApplicationVersion>
+    <ApplicationVersion>2.3.1.0</ApplicationVersion>
     <UseApplicationTrust>false</UseApplicationTrust>
     <BootstrapperEnabled>true</BootstrapperEnabled>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
@@ -26,7 +26,7 @@
     <RootNamespace>Trolley</RootNamespace>
     <PackageId>trolleyhq</PackageId>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>2.3.0</Version>
+    <Version>2.3.1</Version>
     <PackageDescription>The official Trolley .NET SDK to interface with the Trolley API (https://www.trolley.com/)</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright 2020</Copyright>


### PR DESCRIPTION
## Summary
- Bumps the .NET SDK package metadata and source header version to 2.3.1.
- Accepts all 2xx HTTP responses instead of only 200 for client requests.
- Adds generic `Client.Request` / `Gateway.Request` dispatch helpers for custom GET, POST, PATCH, and DELETE calls.
- Adds local HTTP coverage for non-200 success responses and generic PATCH dispatch.

## Test plan
- `dotnet build trolley/trolley.csproj -c Release`
- `dotnet test tests/tests.csproj -c Release --filter FullyQualifiedName~ClientRequestTest`
- Full `dotnet test tests/tests.csproj -c Release` was attempted but requires valid API credentials; available local 1Password test credentials are rejected by the API.

Made with [Cursor](https://cursor.com)