### PR TITLE
Align 2.3.1 version metadata and add version bump guardrails

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,6 +14,9 @@ jobs:
     steps:
       - checkout
       - run:
+          name: Verify version metadata
+          command: bash scripts/verify-version.sh
+      - run:
           name: Install dependencies
           command: dotnet restore trolley.sln
       - run:

--- a/.cursor/rules/version-bump.mdc
+++ b/.cursor/rules/version-bump.mdc
@@ -1,0 +1,37 @@
+---
+description: Keep SDK version metadata consistent across all release files
+globs: trolley/trolley.csproj,trolley/Types/Supporting/SemVer.cs,trolley/Properties/AssemblyInfo.cs,trolley/trolley.nuspec,scripts/**
+alwaysApply: false
+---
+
+# SDK Version Bumps
+
+When changing the .NET SDK release version, update **every** location below in the same change. Do not bump only `trolley.csproj`.
+
+| File | Field | Example for `2.3.1` |
+|------|-------|---------------------|
+| `trolley/trolley.csproj` | `<Version>` | `2.3.1` |
+| `trolley/trolley.csproj` | `<ApplicationVersion>` | `2.3.1.0` |
+| `trolley/Types/Supporting/SemVer.cs` | `MAJOR`, `PATCH`, `MINOR` | `2`, `3`, `1` |
+| `trolley/Properties/AssemblyInfo.cs` | `AssemblyFileVersion` | `2.3.1.0` |
+| `trolley/Properties/AssemblyInfo.cs` | `AssemblyInformationalVersion` | `2.3.1` |
+| `trolley/trolley.nuspec` | `<version>` | `2.3.1` |
+
+Notes:
+- `SemVer.cs` uses `MAJOR.PATCH.MINOR` for the `Trolley-Source` header (not standard SemVer naming).
+- Leave `AssemblyVersion("2.0.0.0")` unchanged unless there is an explicit assembly-version policy change.
+
+After editing, run:
+
+```bash
+scripts/verify-version.sh
+scripts/verify-version.sh 2.3.1   # optional explicit target
+```
+
+Before publishing, run:
+
+```bash
+scripts/cut-release.sh 2.3.1
+```
+
+CI runs `scripts/verify-version.sh` on every PR and push to `main`.

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -18,6 +18,8 @@ jobs:
       TROLLEY_API_BASE_URL: ${{ secrets.TROLLEY_API_BASE_URL }}
     steps:
     - uses: actions/checkout@v4
+    - name: Verify version metadata
+      run: scripts/verify-version.sh
     - name: Setup .NET
       uses: actions/setup-dotnet@v4
       with:

--- a/scripts/cut-release.sh
+++ b/scripts/cut-release.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/cut-release.sh <version> [--publish]
+
+Validates a release candidate for the trolleyhq NuGet package.
+
+Examples:
+  scripts/cut-release.sh 2.3.1
+  scripts/cut-release.sh 2.3.1 --publish
+
+Options:
+  --publish   Trigger the manual NuGet publish workflow for the current commit.
+
+The --publish option must be run from main after the release PR is merged.
+EOF
+}
+
+if [[ $# -lt 1 ]]; then
+  usage
+  exit 1
+fi
+
+version="$1"
+publish="false"
+
+shift
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --publish)
+      publish="true"
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+  shift
+done
+
+if [[ ! "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Version must be SemVer in the form MAJOR.MINOR.PATCH, got: $version" >&2
+  exit 1
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+if [[ -n "$(git status --porcelain)" ]]; then
+  echo "Working tree is not clean. Commit or stash changes before cutting a release." >&2
+  exit 1
+fi
+
+echo "Checking version metadata..."
+scripts/verify-version.sh "$version"
+
+package_file="trolley/bin/Release/trolleyhq.${version}.nupkg"
+
+echo "Restoring dependencies..."
+dotnet restore trolley.sln
+
+echo "Building release package..."
+dotnet build trolley.sln --configuration Release --no-restore
+
+echo "Running local release helper tests..."
+dotnet test tests/tests.sln \
+  --configuration Release \
+  --no-build \
+  --filter FullyQualifiedName~ClientRequestTest
+
+if [[ -n "${TROLLEY_ACCESS_KEY:-}" && -n "${TROLLEY_SECRET_KEY:-}" ]]; then
+  echo "Running integration tests with configured Trolley credentials..."
+  dotnet test tests/tests.sln --configuration Release --no-build
+else
+  echo "Skipping full integration tests because TROLLEY_ACCESS_KEY/TROLLEY_SECRET_KEY are not set."
+fi
+
+if [[ ! -f "$package_file" ]]; then
+  echo "Expected package was not created: $package_file" >&2
+  exit 1
+fi
+
+status="$(curl -s -o /dev/null -w "%{http_code}" "https://api.nuget.org/v3-flatcontainer/trolleyhq/${version}/trolleyhq.${version}.nupkg")"
+if [[ "$status" == "200" ]]; then
+  echo "trolleyhq $version already exists on NuGet." >&2
+  exit 1
+fi
+
+if [[ "$status" != "404" ]]; then
+  echo "Unexpected NuGet availability check status: $status" >&2
+  exit 1
+fi
+
+echo "Release candidate $version is ready."
+
+if [[ "$publish" != "true" ]]; then
+  echo "To publish after merge, run: scripts/cut-release.sh $version --publish"
+  exit 0
+fi
+
+branch="$(git branch --show-current)"
+if [[ "$branch" != "main" ]]; then
+  echo "--publish must be run from main, current branch: $branch" >&2
+  exit 1
+fi
+
+git fetch origin main --quiet
+if [[ "$(git rev-parse HEAD)" != "$(git rev-parse origin/main)" ]]; then
+  echo "Local main is not at origin/main. Pull the latest main before publishing." >&2
+  exit 1
+fi
+
+echo "Triggering NuGet publish workflow..."
+gh workflow run publish-netcore.yml --ref main
+
+echo "Publish workflow triggered. Monitor with: gh run list --workflow publish-netcore.yml --limit 1"

--- a/scripts/verify-version.sh
+++ b/scripts/verify-version.sh
@@ -25,66 +25,67 @@ fi
 repo_root="$(git rev-parse --show-toplevel)"
 cd "$repo_root"
 
-python3 - "${1:-}" <<'PY'
-import re
-import sys
-import xml.etree.ElementTree as ET
-from pathlib import Path
+project_file="trolley/trolley.csproj"
+semver_file="trolley/Types/Supporting/SemVer.cs"
+assembly_info_file="trolley/Properties/AssemblyInfo.cs"
+nuspec_file="trolley/trolley.nuspec"
 
-repo = Path(".")
-expected = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
+first_match() {
+  awk 'NF { print; exit }'
+}
 
-project_file = repo / "trolley/trolley.csproj"
-semver_file = repo / "trolley/Types/Supporting/SemVer.cs"
-assembly_info_file = repo / "trolley/Properties/AssemblyInfo.cs"
-nuspec_file = repo / "trolley/trolley.nuspec"
+xml_value() {
+  local file="$1"
+  local tag="$2"
 
-csproj = ET.parse(project_file)
-project_version = csproj.find(".//Version").text or ""
-application_version = csproj.find(".//ApplicationVersion").text or ""
+  sed -nE "s/.*<${tag}>([^<]+)<\\/${tag}>.*/\\1/p" "$file" | first_match
+}
 
-semver_text = semver_file.read_text()
-semver_parts = {}
-for name in ("MAJOR", "PATCH", "MINOR"):
-    match = re.search(rf"public\s+static\s+int\s+{name}\s*=\s*(\d+)", semver_text)
-    semver_parts[name] = match.group(1) if match else ""
-semver_version = f"{semver_parts['MAJOR']}.{semver_parts['PATCH']}.{semver_parts['MINOR']}"
+semver_part() {
+  local name="$1"
 
-assembly_text = assembly_info_file.read_text()
-file_version_match = re.search(r'AssemblyFileVersion\("([^"]+)"\)', assembly_text)
-info_version_match = re.search(r'AssemblyInformationalVersion\("([^"]+)"\)', assembly_text)
-file_version = file_version_match.group(1) if file_version_match else ""
-info_version = info_version_match.group(1) if info_version_match else ""
+  sed -nE "s/.*public[[:space:]]+static[[:space:]]+int[[:space:]]+${name}[[:space:]]*=[[:space:]]*([0-9]+).*/\\1/p" "$semver_file" | first_match
+}
 
-nuspec_text = nuspec_file.read_text()
-nuspec_match = re.search(r"<version>([^<]+)</version>", nuspec_text)
-nuspec_version = nuspec_match.group(1) if nuspec_match else ""
+assembly_attribute() {
+  local name="$1"
 
-if expected is None:
-    expected = project_version
+  sed -nE "s/.*${name}\\(\"([^\"]+)\"\\).*/\\1/p" "$assembly_info_file" | first_match
+}
 
-errors = []
+project_version="$(xml_value "$project_file" "Version")"
+application_version="$(xml_value "$project_file" "ApplicationVersion")"
+semver_version="$(semver_part "MAJOR").$(semver_part "PATCH").$(semver_part "MINOR")"
+file_version="$(assembly_attribute "AssemblyFileVersion")"
+info_version="$(assembly_attribute "AssemblyInformationalVersion")"
+nuspec_version="$(xml_value "$nuspec_file" "version")"
+expected="${1:-$project_version}"
 
-def check(label, actual, want):
-    if actual != want:
-        errors.append(f"{label}: expected {want!r}, found {actual!r}")
+errors=()
 
-check("trolley/trolley.csproj <Version>", project_version, expected)
-check("trolley/trolley.csproj <ApplicationVersion>", application_version, f"{expected}.0")
-check("trolley/Types/Supporting/SemVer.cs", semver_version, expected)
-check("trolley/Properties/AssemblyInfo.cs AssemblyFileVersion", file_version, f"{expected}.0")
-check("trolley/Properties/AssemblyInfo.cs AssemblyInformationalVersion", info_version, expected)
-check("trolley/trolley.nuspec <version>", nuspec_version, expected)
+check() {
+  local label="$1"
+  local actual="$2"
+  local want="$3"
 
-if errors:
-    print("Version metadata mismatch:", file=sys.stderr)
-    for error in errors:
-        print(f"  - {error}", file=sys.stderr)
-    print(
-        "\nUpdate every location above when bumping the SDK version.",
-        file=sys.stderr,
-    )
-    sys.exit(1)
+  if [[ "$actual" != "$want" ]]; then
+    errors+=("${label}: expected '${want}', found '${actual}'")
+  fi
+}
 
-print(f"Version metadata is consistent at {expected}.")
-PY
+check "trolley/trolley.csproj <Version>" "$project_version" "$expected"
+check "trolley/trolley.csproj <ApplicationVersion>" "$application_version" "${expected}.0"
+check "trolley/Types/Supporting/SemVer.cs" "$semver_version" "$expected"
+check "trolley/Properties/AssemblyInfo.cs AssemblyFileVersion" "$file_version" "${expected}.0"
+check "trolley/Properties/AssemblyInfo.cs AssemblyInformationalVersion" "$info_version" "$expected"
+check "trolley/trolley.nuspec <version>" "$nuspec_version" "$expected"
+
+if (( ${#errors[@]} > 0 )); then
+  echo "Version metadata mismatch:" >&2
+  printf '  - %s\n' "${errors[@]}" >&2
+  echo >&2
+  echo "Update every location above when bumping the SDK version." >&2
+  exit 1
+fi
+
+echo "Version metadata is consistent at ${expected}."

--- a/scripts/verify-version.sh
+++ b/scripts/verify-version.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/verify-version.sh [version]
+
+Verify SDK version metadata is consistent across all release files.
+
+If version is omitted, the canonical version is read from trolley/trolley.csproj.
+
+Checked locations:
+  - trolley/trolley.csproj (<Version>, <ApplicationVersion>)
+  - trolley/Types/Supporting/SemVer.cs (MAJOR, PATCH, MINOR -> User-Agent)
+  - trolley/Properties/AssemblyInfo.cs (AssemblyFileVersion, AssemblyInformationalVersion)
+  - trolley/trolley.nuspec (<version>)
+EOF
+}
+
+if [[ "${1:-}" == "-h" || "${1:-}" == "--help" ]]; then
+  usage
+  exit 0
+fi
+
+repo_root="$(git rev-parse --show-toplevel)"
+cd "$repo_root"
+
+python3 - "${1:-}" <<'PY'
+import re
+import sys
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+repo = Path(".")
+expected = sys.argv[1] if len(sys.argv) > 1 and sys.argv[1] else None
+
+project_file = repo / "trolley/trolley.csproj"
+semver_file = repo / "trolley/Types/Supporting/SemVer.cs"
+assembly_info_file = repo / "trolley/Properties/AssemblyInfo.cs"
+nuspec_file = repo / "trolley/trolley.nuspec"
+
+csproj = ET.parse(project_file)
+project_version = csproj.find(".//Version").text or ""
+application_version = csproj.find(".//ApplicationVersion").text or ""
+
+semver_text = semver_file.read_text()
+semver_parts = {}
+for name in ("MAJOR", "PATCH", "MINOR"):
+    match = re.search(rf"public\s+static\s+int\s+{name}\s*=\s*(\d+)", semver_text)
+    semver_parts[name] = match.group(1) if match else ""
+semver_version = f"{semver_parts['MAJOR']}.{semver_parts['PATCH']}.{semver_parts['MINOR']}"
+
+assembly_text = assembly_info_file.read_text()
+file_version_match = re.search(r'AssemblyFileVersion\("([^"]+)"\)', assembly_text)
+info_version_match = re.search(r'AssemblyInformationalVersion\("([^"]+)"\)', assembly_text)
+file_version = file_version_match.group(1) if file_version_match else ""
+info_version = info_version_match.group(1) if info_version_match else ""
+
+nuspec_text = nuspec_file.read_text()
+nuspec_match = re.search(r"<version>([^<]+)</version>", nuspec_text)
+nuspec_version = nuspec_match.group(1) if nuspec_match else ""
+
+if expected is None:
+    expected = project_version
+
+errors = []
+
+def check(label, actual, want):
+    if actual != want:
+        errors.append(f"{label}: expected {want!r}, found {actual!r}")
+
+check("trolley/trolley.csproj <Version>", project_version, expected)
+check("trolley/trolley.csproj <ApplicationVersion>", application_version, f"{expected}.0")
+check("trolley/Types/Supporting/SemVer.cs", semver_version, expected)
+check("trolley/Properties/AssemblyInfo.cs AssemblyFileVersion", file_version, f"{expected}.0")
+check("trolley/Properties/AssemblyInfo.cs AssemblyInformationalVersion", info_version, expected)
+check("trolley/trolley.nuspec <version>", nuspec_version, expected)
+
+if errors:
+    print("Version metadata mismatch:", file=sys.stderr)
+    for error in errors:
+        print(f"  - {error}", file=sys.stderr)
+    print(
+        "\nUpdate every location above when bumping the SDK version.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
+
+print(f"Version metadata is consistent at {expected}.")
+PY

--- a/trolley/Properties/AssemblyInfo.cs
+++ b/trolley/Properties/AssemblyInfo.cs
@@ -32,5 +32,5 @@ using System.Runtime.InteropServices;
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("2.0.0.0")]
-[assembly: AssemblyFileVersion("2.3.0.0")]
-[assembly: AssemblyInformationalVersion("2.3.0")]
+[assembly: AssemblyFileVersion("2.3.1.0")]
+[assembly: AssemblyInformationalVersion("2.3.1")]

--- a/trolley/trolley.csproj
+++ b/trolley/trolley.csproj
@@ -30,7 +30,7 @@
     <PackageDescription>The official Trolley .NET SDK to interface with the Trolley API (https://www.trolley.com/)</PackageDescription>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Copyright>Copyright 2020</Copyright>
-    <Authors>Jesse Tremblay, Jesse Silber, Joshua Cunningham, Aman Aalam</Authors>
+    <Authors>Jesse Tremblay, Jesse Silber, Joshua Cunningham, Aman Aalam, Barnett Klane</Authors>
     <PackageTags>Trolley net sdk PaymentRails</PackageTags>
     <RepositoryUrl>https://github.com/Trolley/dotnet-sdk/</RepositoryUrl>
     <RepositoryType>Git</RepositoryType>

--- a/trolley/trolley.nuspec
+++ b/trolley/trolley.nuspec
@@ -4,7 +4,7 @@
     <id>trolleyhq</id>
     <version>2.3.1</version>
     <title>$title$</title>
-    <authors>Jesse Tremblay, Jesse Silber, Joshua Cunningham, Aman Aalam</authors>
+    <authors>Jesse Tremblay, Jesse Silber, Joshua Cunningham, Aman Aalam, Barnett Klane</authors>
     <owners>aman.trolley, trolley-developers, PaymentRailsJesse, joshuapr</owners>
     <projectUrl>https://github.com/Trolley/dotnet-sdk</projectUrl>
     <requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/trolley/trolley.nuspec
+++ b/trolley/trolley.nuspec
@@ -2,7 +2,7 @@
 <package >
   <metadata>
     <id>trolleyhq</id>
-    <version>2.3.0</version>
+    <version>2.3.1</version>
     <title>$title$</title>
     <authors>Jesse Tremblay, Jesse Silber, Joshua Cunningham, Aman Aalam</authors>
     <owners>aman.trolley, trolley-developers, PaymentRailsJesse, joshuapr</owners>


### PR DESCRIPTION
## Summary
- Aligns `AssemblyInfo.cs` and `trolley.nuspec` with the published `2.3.1` release.
- Adds `scripts/verify-version.sh` to check all SDK version locations stay in sync.
- Adds `scripts/cut-release.sh` for release validation/publish workflow (reuses the verifier).
- Adds `.cursor/rules/version-bump.mdc` so agents and contributors know every file to update.
- Runs version verification in GitHub Actions and CircleCI on every PR/push to `main`.

## Version locations enforced
- `trolley/trolley.csproj` (`Version`, `ApplicationVersion`)
- `trolley/Types/Supporting/SemVer.cs` (`MAJOR`, `PATCH`, `MINOR`)
- `trolley/Properties/AssemblyInfo.cs` (`AssemblyFileVersion`, `AssemblyInformationalVersion`)
- `trolley/trolley.nuspec` (`<version>`)

## Test plan
- [x] `scripts/verify-version.sh`
- [x] `scripts/verify-version.sh 2.3.1`
- [ ] CI passes on this PR