### PR TITLE
chore(ci): migrate codecov upload to codecov-cli v11.2.8 [SRE-1580]

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,6 @@
 version: 2.1
 
 orbs:
-  codecov: codecov/codecov@5.0.3
 
 defaults: &defaults
   working_directory: ~/project
@@ -41,13 +40,15 @@ jobs:
       - run:
           name: Install GPG
           command: apt-get update -qq && apt-get install -y gnupg
-      - codecov/upload:
-          token: CODECOV_TOKEN
-          slug: trolley/dotnet-sdk
-          files: coverage/**/coverage.cobertura.xml
-          handle_no_reports_found: true
+      - run:
+          name: Upload coverage to Codecov
           when: always
-
+          command: |
+            curl -Os https://github.com/codecov/codecov-cli/releases/download/v11.2.8/codecovcli_linux
+            chmod +x codecovcli_linux
+            ./codecovcli_linux create-commit -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1
+            ./codecovcli_linux create-report -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1
+            ./codecovcli_linux do-upload -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1 --file coverage/coverage-final.json
 workflows:
   version: 2
   build:


### PR DESCRIPTION
## Summary
- Removes `codecov/codecov` orb from the `orbs:` section
- Replaces `codecov/upload` step with direct `codecov-cli` v11.2.8 run step
- Uses `create-commit`, `create-report`, and `do-upload` subcommands

## Changes
```diff
-  codecov: codecov/codecov@<version>

-      - codecov/upload:
-          token: CODECOV_TOKEN
-          slug: trolley/dotnet-sdk
+      - run:
+          name: Upload coverage to Codecov
+          when: always
+          command: |
+            curl -Os https://github.com/codecov/codecov-cli/releases/download/v11.2.8/codecovcli_linux
+            chmod +x codecovcli_linux
+            ./codecovcli_linux create-commit -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1
+            ./codecovcli_linux create-report -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1
+            ./codecovcli_linux do-upload -t $CODECOV_TOKEN --slug trolley/dotnet-sdk --git-service github -C $CIRCLE_SHA1 --file coverage/coverage-final.json
```

## Ticket
SRE-1580